### PR TITLE
Service monitor should use metrics port

### DIFF
--- a/deploy/charts/cert-checker/templates/servicemonitor.yaml
+++ b/deploy/charts/cert-checker/templates/servicemonitor.yaml
@@ -13,5 +13,5 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "cert-checker.fullname" . }}
   endpoints:
-  - port: http
+  - port: metrics-http
 {{- end }}


### PR DESCRIPTION
Currently, the manifest template for the service monitor is using the `http` port. It should use the `metrics-port` instead.