### PR TITLE
Allow users to individualize date formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Create a config file like the below example:
 loglevel: debug
 port: 8080  # Optional
 intervalminutes: 10
+dateformat: YYYY-MM-DD # Optional (example: dd.MM.YYYY)
 certificates:
     - dns: google.com
     - dns: expired.badssl.com
@@ -273,6 +274,16 @@ By default, without the flag `-c, --config`, cert-checker will
 use a config file located next to the binary named `config.yaml`.
 
 This is currently the only flag / option available.
+
+The `config.yaml` supports these settings:
+- `loglevel`
+- `port`
+- `webport`
+- `intervalminutes`
+- `dateformat` (optional, defaults to `YYYY-MM-DD`)
+- `certificates`
+
+Supported `dateformat` tokens are `YYYY`, `YY`, `MM`, `dd`, `HH`, `mm`, and `ss`.
 
 ```bash
 $ cert-checker -h

--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -70,7 +70,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 			// Web UI
 
 			webAddress := fmt.Sprintf("%s:%d", "0.0.0.0", opts.WebPort)
-			ui := web.New(c, webAddress, log)
+			ui := web.New(c, webAddress, opts.DateFormat, log)
 
 			go func() {
 				<-ctx.Done()

--- a/cmd/app/config.go
+++ b/cmd/app/config.go
@@ -13,6 +13,7 @@ type options struct {
 	Port            int                  `yaml:"port"`
 	WebPort         int                  `yaml:"webport"`
 	LogLevel        string               `yaml:"loglevel"`
+	DateFormat      string               `yaml:"dateformat"`
 	Certificates    []models.Certificate `yaml:"certificates"`
 
 	// IntervalDuration is computed from IntervalMinutes
@@ -34,6 +35,9 @@ func newOptionsFromFile(fileName string) (*options, error) {
 	}
 	if opts.WebPort == 0 {
 		opts.WebPort = 8081
+	}
+	if opts.DateFormat == "" {
+		opts.DateFormat = "YYYY-MM-DD"
 	}
 	opts.IntervalDuration = time.Duration(int64(opts.IntervalMinutes)) * time.Minute
 	return opts, nil

--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,7 @@ loglevel: debug
 port: 8080
 webport: 8081
 intervalminutes: 1
+dateformat: YYYY-MM-DD
 certificates:
     - dns: twitter.com
     - dns: google.com

--- a/deploy/charts/cert-checker/values.yaml
+++ b/deploy/charts/cert-checker/values.yaml
@@ -44,6 +44,7 @@ readinessProbe:
 certchecker:
   loglevel: info
   intervalminutes: 1
+  dateformat: YYYY-MM-DD
   certificates:
     - dns: google.com
     - dns: example.com

--- a/deploy/docker-compose/cert-checker/config.yaml
+++ b/deploy/docker-compose/cert-checker/config.yaml
@@ -1,6 +1,7 @@
 loglevel: debug
 port: 8080  # Optional
 intervalminutes: 2
+dateformat: YYYY-MM-DD
 certificates:
     # Is good, but has old TSL 1.0
     - dns: google.com

--- a/deploy/yaml/deploy.yaml
+++ b/deploy/yaml/deploy.yaml
@@ -33,6 +33,7 @@ data:
       - dns: rc4-md5.badssl.com
       - dns: rc4.badssl.com
       intervalminutes: 1
+      dateformat: YYYY-MM-DD
       loglevel: info
 ---
 apiVersion: v1

--- a/pkg/web/dateformat.go
+++ b/pkg/web/dateformat.go
@@ -1,0 +1,62 @@
+package web
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const (
+	defaultDateFormat = "YYYY-MM-DD"
+)
+
+var unsupportedDateTokens = regexp.MustCompile(`[A-Za-z]`)
+
+type formatter struct {
+	ConfigLayout string
+	GoLayout     string
+}
+
+func defaultFormatter() formatter {
+	return formatter{
+		ConfigLayout: defaultDateFormat,
+		GoLayout:     "2006-01-02",
+	}
+}
+
+func newFormatter(layout string) (formatter, error) {
+	if layout == "" {
+		return defaultFormatter(), nil
+	}
+
+	goLayout := strings.NewReplacer(
+		"yyyy", "2006",
+		"YYYY", "2006",
+		"YY", "06",
+		"yy", "06",
+		"DD", "02",
+		"MM", "01",
+		"dd", "02",
+		"HH", "15",
+		"mm", "04",
+		"ss", "05",
+	).Replace(layout)
+
+	if unsupportedDateTokens.MatchString(goLayout) {
+		return formatter{}, fmt.Errorf("unsupported date format token in %q", layout)
+	}
+
+	if _, err := time.Parse(goLayout, time.Now().Format(goLayout)); err != nil {
+		return formatter{}, fmt.Errorf("invalid date format %q: %w", layout, err)
+	}
+
+	return formatter{
+		ConfigLayout: layout,
+		GoLayout:     goLayout,
+	}, nil
+}
+
+func (f formatter) Format(t time.Time) string {
+	return t.Format(f.GoLayout)
+}

--- a/pkg/web/dateformat_test.go
+++ b/pkg/web/dateformat_test.go
@@ -1,0 +1,73 @@
+package web
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewFormatter(t *testing.T) {
+	tests := []struct {
+		name       string
+		in         string
+		wantLayout string
+		wantErr    bool
+	}{
+		{
+			name:       "default empty",
+			in:         "",
+			wantLayout: "2006-01-02",
+		},
+		{
+			name:       "default explicit",
+			in:         "YYYY-MM-DD",
+			wantLayout: "2006-01-02",
+		},
+		{
+			name:       "dots with day first",
+			in:         "dd.MM.YYYY",
+			wantLayout: "02.01.2006",
+		},
+		{
+			name:       "with clock",
+			in:         "YYYY-MM-DD HH:mm:ss",
+			wantLayout: "2006-01-02 15:04:05",
+		},
+		{
+			name:    "unsupported token",
+			in:      "QQ.MM.YYYY",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := newFormatter(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for input %q", tt.in)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if f.GoLayout != tt.wantLayout {
+				t.Fatalf("expected go layout %q, got %q", tt.wantLayout, f.GoLayout)
+			}
+		})
+	}
+}
+
+func TestFormatterFormat(t *testing.T) {
+	f, err := newFormatter("dd.MM.YYYY")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	in := time.Date(2026, 4, 15, 14, 30, 0, 0, time.UTC)
+	got := f.Format(in)
+	if got != "15.04.2026" {
+		t.Fatalf("expected 15.04.2026, got %q", got)
+	}
+}

--- a/pkg/web/html.go
+++ b/pkg/web/html.go
@@ -18,7 +18,7 @@ var views embed.FS
 var minExpireDays = 30
 
 // templateHTML generates an html representation for the given certs, and writes the result to the io.writer
-func templateHTML(certs []models.Certificate, w io.Writer) error {
+func templateHTML(certs []models.Certificate, w io.Writer, dateFormat formatter) error {
 
 	sum := internalSummery{}
 
@@ -30,8 +30,8 @@ func templateHTML(certs []models.Certificate, w io.Writer) error {
 		uiC := uiCert{
 			DNS:               c.DNS,
 			Issuer:            c.Info.Issuer,
-			NotAfter:          c.Info.Detail().NotAfter.Format("2006-01-02"),
-			NotBefore:         c.Info.Detail().NotBefore.Format("2006-01-02"),
+			NotAfter:          dateFormat.Format(c.Info.Detail().NotAfter),
+			NotBefore:         dateFormat.Format(c.Info.Detail().NotBefore),
 			MinimumTLSVersion: c.Info.MinimumTLSVersion,
 			Warning:           warning(c),
 			Error:             c.Info.Error,
@@ -47,7 +47,7 @@ func templateHTML(certs []models.Certificate, w io.Writer) error {
 		}
 	}
 
-	t := template.Must(template.New("index.html").Funcs(getFunctions()).ParseFS(views, "views/*"))
+	t := template.Must(template.New("index.html").Funcs(getFunctions(dateFormat)).ParseFS(views, "views/*"))
 	err := t.Execute(w, sum)
 	if err != nil {
 		return err

--- a/pkg/web/templatefuncs.go
+++ b/pkg/web/templatefuncs.go
@@ -5,16 +5,20 @@ import (
 	"time"
 )
 
-func getFunctions() template.FuncMap {
+func getFunctions(f formatter) template.FuncMap {
 	return template.FuncMap{
-		"timeNow":         templateTimeNow,
-		"tlsToCSS":        templateTLSToCSS,
-		"expireTimeToCSS": templateExpireTimeToCSS,
+		"timeNow": func() string {
+			return templateTimeNow(f)
+		},
+		"tlsToCSS": templateTLSToCSS,
+		"expireTimeToCSS": func(ts string) string {
+			return templateExpireTimeToCSS(ts, f)
+		},
 	}
 }
 
-func templateTimeNow() string {
-	return time.Now().Format("2006-01-02 15:04:05")
+func templateTimeNow(f formatter) string {
+	return f.Format(time.Now())
 }
 
 func templateTLSToCSS(tlsStr string) string {
@@ -33,16 +37,16 @@ func templateTLSToCSS(tlsStr string) string {
 	return "failed"
 }
 
-func parseTime(s string) *time.Time {
-	parsedTime, err := time.Parse("2006-01-02", s)
+func parseTime(s string, f formatter) *time.Time {
+	parsedTime, err := time.Parse(f.GoLayout, s)
 	if err != nil || (parsedTime == time.Time{}) {
 		return nil
 	}
 	return &parsedTime
 }
 
-func templateExpireTimeToCSS(ts string) string {
-	parsedTime := parseTime(ts)
+func templateExpireTimeToCSS(ts string, f formatter) string {
+	parsedTime := parseTime(ts, f)
 	if parsedTime == nil {
 		return "hidden"
 	}

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -16,6 +16,7 @@ type UI struct {
 
 	certService certProvider
 	webAddress  string
+	dateFormat  formatter
 	server      *http.Server
 }
 
@@ -24,10 +25,17 @@ type certProvider interface {
 }
 
 // New returns a new configured instance of the UI struct
-func New(certService certProvider, webAddress string, log *logrus.Entry) *UI {
+func New(certService certProvider, webAddress string, dateFormat string, log *logrus.Entry) *UI {
+	f, err := newFormatter(dateFormat)
+	if err != nil {
+		log.WithError(err).Warnf("invalid date format %q, using default YYYY-MM-DD", dateFormat)
+		f = defaultFormatter()
+	}
+
 	return &UI{
 		webAddress:  webAddress,
 		certService: certService,
+		dateFormat:  f,
 		log:         log,
 	}
 }
@@ -82,7 +90,7 @@ func (u *UI) handleFunc() http.Handler {
 
 		certs := u.certService.Certs()
 
-		err := templateHTML(certs, w)
+		err := templateHTML(certs, w, u.dateFormat)
 		if err != nil {
 			logrus.Printf("Error templating: %v\n", err)
 		}


### PR DESCRIPTION
## Summary
- add configurable `dateformat` support in `config.yaml` and propagate it to the web UI renderer
- render and parse certificate dates using token-based user formats (for example `dd.MM.YYYY`) with validation and default fallback behavior
- update docs and deployment/sample configs, and add tests for date format conversion and output formatting

## Test plan
- [x] Run `go test ./...`
- [ ] Start the app with `dateformat: dd.MM.YYYY` and verify UI dates are displayed as day-month-year
- [ ] Start the app with an invalid `dateformat` and verify fallback to default format with warning log